### PR TITLE
add moduledocs

### DIFF
--- a/lib/tflite_elixir/flat_buffer_model.ex
+++ b/lib/tflite_elixir/flat_buffer_model.ex
@@ -1,4 +1,8 @@
 defmodule TFLiteElixir.FlatBufferModel do
+  @moduledoc """
+  An RAII object that represents a read-only tflite model, copied from disk, or
+  mmapped.
+  """
   import TFLiteElixir.Errorize
 
   @type nif_error :: {:error, String.t()}

--- a/lib/tflite_elixir/interpreter.ex
+++ b/lib/tflite_elixir/interpreter.ex
@@ -1,4 +1,7 @@
 defmodule TFLiteElixir.Interpreter do
+  @moduledoc """
+  An interpreter for a graph of nodes that input and output from tensors.
+  """
   import TFLiteElixir.Errorize
   alias TFLiteElixir.TFLiteTensor
   alias TFLiteElixir.TFLiteQuantizationParams

--- a/lib/tflite_elixir/interpreter_builder.ex
+++ b/lib/tflite_elixir/interpreter_builder.ex
@@ -1,6 +1,9 @@
 defmodule TFLiteElixir.InterpreterBuilder do
+  @moduledoc """
+  Build an interpreter capable of interpreting model.
+  """
   import TFLiteElixir.Errorize
-  alias TFLiteElixir.FlatBufferModel, as: FlatBufferModel
+  alias TFLiteElixir.FlatBufferModel
 
   @type nif_resource_ok :: {:ok, reference()}
   @type nif_error :: {:error, String.t()}

--- a/lib/tflite_elixir/quantization_params.ex
+++ b/lib/tflite_elixir/quantization_params.ex
@@ -1,3 +1,9 @@
 defmodule TFLiteElixir.TFLiteQuantizationParams do
+  @moduledoc """
+  Quantization parameters that corresponds to the table QuantizationParameters
+  in the [TFLite Model schema file].
+
+  [TFLite Model schema file]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs
+  """
   defstruct [:scale, :zero_point, :quantized_dimension]
 end

--- a/lib/tflite_elixir/tflite_tensor.ex
+++ b/lib/tflite_elixir/tflite_tensor.ex
@@ -1,4 +1,7 @@
 defmodule TFLiteElixir.TFLiteTensor do
+  @moduledoc """
+  A typed multi-dimensional array used in Tensorflow Lite.
+  """
   import TFLiteElixir.Errorize
 
   @behaviour Nx.Backend


### PR DESCRIPTION
### Description

Add moduledocs to Elixir modules.

### Notes

- I excluded a few modules below because of my lack of understanding
  - TFLiteElixir
  - TFLiteElixir.Coral
  - TFLiteElixir.Ops.Builtin.BuiltinResolver