### PR TITLE
snake case fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ labels = File.read!("inat_bird_labels.txt") |> String.split("\n")
 
 # load tflite model
 filename = "mobilenet_v2_1.0_224_inat_bird_quant.tflite"
-model = TFLite.FlatBufferModel.buildFromFile!(filename)
+model = TFLite.FlatBufferModel.build_from_file!(filename)
 resolver = TFLite.Ops.Builtin.BuiltinResolver.new!()
 builder = TFLite.InterpreterBuilder.new!(model, resolver)
 interpreter = TFLite.Interpreter.new!()

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Mix.install([
 
 # parrot.jpeg and the tflite file can be found in the test/test_data directory
 interpreter = TFLiteElixir.Interpreter.new!("/path/to/mobilenet_v2_1.0_224_inat_bird_quant.tflite")
-input = 
+input =
   StbImage.read_file!("/path/to/parrot.jpeg")
   |> StbImage.resize(224, 224)
   |> StbImage.to_nx()
 
 [output_tensor_0] = TFLiteElixir.Interpreter.predict(interpreter, input)
-nx_tensor = 
+nx_tensor =
   TFLiteElixir.TFLiteTensor.to_binary(output_tensor_0)
   |> Nx.from_binary(:u8)
 
@@ -78,7 +78,7 @@ Coracias caudatus (Lilac-breasted Roller): 0.01953
 
 [![Nerves](https://github-actions.40ants.com/cocoa-xu/tflite_elixir/matrix.svg?only=nerves-build)](https://github.com/cocoa-xu/tflite_elixir)
 
-Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/actions/workflows/nerves-build.yml?query=is%3Asuccess). 
+Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/actions/workflows/nerves-build.yml?query=is%3Asuccess).
 
 Select the most recent run and scroll down to the `Artifacts` section, download the firmware file for your board and run
 
@@ -86,7 +86,7 @@ Select the most recent run and scroll down to the `Artifacts` section, download 
 fwup /path/to/the/downloaded/firmware.fw
 ```
 
-In the nerves build, `tflite_elixir` is integrated as one of the dependencies of the [nerves_livebook](https://github.com/livebook-dev/nerves_livebook) project. This means that you can use livebook (as well as other pre-pulled libraries) to explore and evaluate the `tflite_elixir` project. 
+In the nerves build, `tflite_elixir` is integrated as one of the dependencies of the [nerves_livebook](https://github.com/livebook-dev/nerves_livebook) project. This means that you can use livebook (as well as other pre-pulled libraries) to explore and evaluate the `tflite_elixir` project.
 
 The default password of the livebook is `nerves` (as the time of writing, if it does not work, please check the nerves_livebook project).
 
@@ -97,13 +97,13 @@ The default password of the livebook is `nerves` (as the time of writing, if it 
 # for example
 export MIX_TARGET=rpi4
 
-# There is no need to explicitly set CPU architecture 
+# There is no need to explicitly set CPU architecture
 #   for the precompiled libedgetpu binaries. The arch
 #   is automatically detected by the `TARGET_ARCH`,
 #   `TARGET_OS` and `TARGET_ABI` environment vars.
 #
 # However, if you are using your own nerves target
-#   you can manually set the correct arch, e.g., 
+#   you can manually set the correct arch, e.g.,
 #   set `aarch64` for rpi4.
 #
 # Possible values including
@@ -178,7 +178,7 @@ test files used here are downloaded from [google-coral/test_data](https://github
 ### Demo code
 Model: [mobilenet_v2_1.0_224_inat_bird_quant.tflite](https://github.com/google-coral/edgetpu/blob/master/test_data/mobilenet_v2_1.0_224_inat_bird_quant.tflite)
 
-Input image: 
+Input image:
 - [parrot.jpg](https://github.com/google-coral/edgetpu/blob/master/test_data/parrot.jpg)
 - Or use pre-converted input [parrot.bin](https://github.com/cocoa-xu/tflite_elixir/blob/main/test/test_data/parrot.bin)
 
@@ -198,13 +198,13 @@ resolver = TFLite.Ops.Builtin.BuiltinResolver.new!()
 builder = TFLite.InterpreterBuilder.new!(model, resolver)
 interpreter = TFLite.Interpreter.new!()
 :ok = TFLite.InterpreterBuilder.build!(builder, interpreter)
-:ok = TFLite.Interpreter.allocateTensors!(interpreter)
+:ok = TFLite.Interpreter.allocate_tensors!(interpreter)
 
 # verify loaded model, feel free to skip
 # [0] = TFLite.Interpreter.inputs!(interpreter)
 # [171] = TFLite.Interpreter.outputs!(interpreter)
-# "map/TensorArrayStack/TensorArrayGatherV3" = TFLite.Interpreter.getInputName!(interpreter, 0)
-# "prediction" = TFLite.Interpreter.getOutputName!(interpreter, 0)
+# "map/TensorArrayStack/TensorArrayGatherV3" = TFLite.Interpreter.get_input_name!(interpreter, 0)
+# "prediction" = TFLite.Interpreter.get_output_name!(interpreter, 0)
 # input_tensor = TFLite.Interpreter.tensor!(interpreter, 0)
 # [1, 224, 224, 3] = TFLite.TFLiteTensor.dims!(input_tensor)
 # {:u, 8} = TFLite.TFLiteTensor.type(input_tensor)
@@ -215,8 +215,8 @@ interpreter = TFLite.Interpreter.new!()
 # parrot.bin - if you don't have :evision
 binary = File.read!("parrot.bin")
 # parrot.jpg - if you have :evision
-# load image, resize it, covert to RGB and to binary 
-binary = 
+# load image, resize it, covert to RGB and to binary
+binary =
   Cv.imread("parrot.jpg")
   |> Cv.resize({224, 224})
   |> Cv.cvtColor(Cv.cv_COLOR_BGR2RGB)
@@ -262,18 +262,18 @@ bash "3rd_party/cache/${TFLITE_ELIXIR_CORAL_LIBEDGETPU_RUNTIME}/edgetpu_runtime/
 - `TFLITE_ELIXIR_CORAL_USB_THROTTLE`
 
   Throttling USB Coral Devices. Please see the official warning here, [google-coral/libedgetpu](https://github.com/google-coral/libedgetpu#warning).
-  
+
   Default value is `YES`.
-  
+
   Note that only when `TFLITE_ELIXIR_CORAL_USB_THROTTLE` is set to `NO`, `:tflite_elixir` will use the non-throttled libedgetpu libraries.
 
 - `TFLITE_ELIXIR_CORAL_LIBEDGETPU_LIBRARIES`
-  
+
   Choose which ones of the libedgetpu libraries to copy to the `priv` directory of the `:tflite_elixir` app.
 
   Default value is `native` - only native libraries will be downloaded and copied. `native` corresponds to the host OS and CPU architecture when compiling this library.
 
-  When set to a specific value, e.g, `darwin_arm64` or `darwin_x86_64`, then the corresponding one will be downloaded and copied. This option is expected to be used for cross-compiling, like with nerves. 
+  When set to a specific value, e.g, `darwin_arm64` or `darwin_x86_64`, then the corresponding one will be downloaded and copied. This option is expected to be used for cross-compiling, like with nerves.
 
   Available values for this option are:
 
@@ -290,7 +290,7 @@ bash "3rd_party/cache/${TFLITE_ELIXIR_CORAL_LIBEDGETPU_RUNTIME}/edgetpu_runtime/
 
 
 - `TFLITE_ELIXIR_CACHE_DIR`
-  
+
   Cache directory for the runtime zip file.
 
   Default value is `./3rd_party/cache`.

--- a/examples/tflite_benchmark_densenet.livemd
+++ b/examples/tflite_benchmark_densenet.livemd
@@ -217,7 +217,7 @@ defmodule ClassifyImage do
   end
 
   defp load_model(model_path) do
-    FlatBufferModel.buildFromBuffer!(File.read!(model_path))
+    FlatBufferModel.build_from_buffer!(File.read!(model_path))
   end
 
   defp load_input(nil) do

--- a/examples/tflite_benchmark_densenet.livemd
+++ b/examples/tflite_benchmark_densenet.livemd
@@ -122,7 +122,7 @@ defmodule ClassifyImage do
       end
 
     interpreter = make_interpreter(model, args[:jobs], args[:use_tpu], tpu_context)
-    Interpreter.allocateTensors!(interpreter)
+    Interpreter.allocate_tensors!(interpreter)
 
     [input_tensor_number | _] = Interpreter.inputs!(interpreter)
     [output_tensor_number | _] = Interpreter.outputs!(interpreter)

--- a/examples/tpu.livemd
+++ b/examples/tpu.livemd
@@ -112,7 +112,7 @@ defmodule ClassifyImage do
       end
 
     interpreter = make_interpreter(model, args[:jobs], args[:use_tpu], tpu_context)
-    Interpreter.allocateTensors!(interpreter)
+    Interpreter.allocate_tensors!(interpreter)
 
     [input_tensor_number | _] = Interpreter.inputs!(interpreter)
     [output_tensor_number | _] = Interpreter.outputs!(interpreter)

--- a/examples/tpu.livemd
+++ b/examples/tpu.livemd
@@ -197,7 +197,7 @@ defmodule ClassifyImage do
   end
 
   defp load_model(model_path) do
-    FlatBufferModel.buildFromBuffer!(File.read!(model_path))
+    FlatBufferModel.build_from_buffer!(File.read!(model_path))
   end
 
   defp load_input(nil) do

--- a/lib/tasks/classify_image.ex
+++ b/lib/tasks/classify_image.ex
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.ClassifyImage do
       end
 
     interpreter = make_interpreter(model, args[:jobs], args[:use_tpu], tpu_context)
-    Interpreter.allocateTensors!(interpreter)
+    Interpreter.allocate_tensors!(interpreter)
 
     [input_tensor_number | _] = Interpreter.inputs!(interpreter)
     [output_tensor_number | _] = Interpreter.outputs!(interpreter)
@@ -204,9 +204,9 @@ defmodule Mix.Tasks.ClassifyImage do
     resolver = TFLiteElixir.Ops.Builtin.BuiltinResolver.new!()
     builder = InterpreterBuilder.new!(model, resolver)
     interpreter = Interpreter.new!()
-    InterpreterBuilder.setNumThreads!(builder, num_jobs)
+    InterpreterBuilder.set_num_threads!(builder, num_jobs)
     :ok = InterpreterBuilder.build!(builder, interpreter)
-    Interpreter.setNumThreads!(interpreter, num_jobs)
+    Interpreter.set_num_threads!(interpreter, num_jobs)
     interpreter
   end
 

--- a/lib/tasks/classify_image.ex
+++ b/lib/tasks/classify_image.ex
@@ -177,7 +177,7 @@ defmodule Mix.Tasks.ClassifyImage do
   end
 
   defp load_model(model_path) do
-    FlatBufferModel.buildFromBuffer!(File.read!(model_path))
+    FlatBufferModel.build_from_buffer!(File.read!(model_path))
   end
 
   defp load_input(nil) do

--- a/lib/tasks/detect_image.ex
+++ b/lib/tasks/detect_image.ex
@@ -207,7 +207,7 @@ defmodule Mix.Tasks.DetectImage do
   end
 
   defp load_model(model_path) do
-    FlatBufferModel.buildFromBuffer!(File.read!(model_path))
+    FlatBufferModel.build_from_buffer!(File.read!(model_path))
   end
 
   defp load_input(nil) do

--- a/lib/tasks/detect_image.ex
+++ b/lib/tasks/detect_image.ex
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.DetectImage do
     input_image = %StbImage{shape: {h, w, _c}} = load_input(args[:input])
     labels = load_labels(args[:labels])
     interpreter = make_interpreter(model, args[:jobs])
-    Interpreter.allocateTensors!(interpreter)
+    Interpreter.allocate_tensors!(interpreter)
 
     [input_tensor_number | _] = Interpreter.inputs!(interpreter)
     output_tensor_numbers = Interpreter.outputs!(interpreter)
@@ -234,9 +234,9 @@ defmodule Mix.Tasks.DetectImage do
     resolver = TFLiteElixir.Ops.Builtin.BuiltinResolver.new!()
     builder = InterpreterBuilder.new!(model, resolver)
     interpreter = Interpreter.new!()
-    InterpreterBuilder.setNumThreads!(builder, num_jobs)
+    InterpreterBuilder.set_num_threads!(builder, num_jobs)
     :ok = InterpreterBuilder.build!(builder, interpreter)
-    Interpreter.setNumThreads!(interpreter, num_jobs)
+    Interpreter.set_num_threads!(interpreter, num_jobs)
     interpreter
   end
 

--- a/lib/tflite_elixir.ex
+++ b/lib/tflite_elixir.ex
@@ -6,13 +6,13 @@ defmodule TFLiteElixir do
 
   Note that this function directly prints to stdout
   """
-  @spec printInterpreterState(reference()) :: nil
-  def printInterpreterState(interpreter) do
+  @spec print_interpreter_state(reference()) :: nil
+  def print_interpreter_state(interpreter) do
     TFLiteElixir.Nif.tflite_printInterpreterState(interpreter)
     nil
   end
 
-  def resetVariableTensor(%TFLiteTensor{}=tflite_tensor) do
+  def reset_variable_tensor(%TFLiteTensor{}=tflite_tensor) do
     TFLiteElixir.Nif.tflite_resetVariableTensor(tflite_tensor)
   end
 end

--- a/lib/tflite_elixir/coral.ex
+++ b/lib/tflite_elixir/coral.ex
@@ -1,14 +1,14 @@
 defmodule TFLiteElixir.Coral do
   import TFLiteElixir.Errorize
 
-  alias TFLiteElixir.FlatBufferModel, as: FlatBufferModel
+  alias TFLiteElixir.FlatBufferModel
 
-  def containsEdgeTpuCustomOp?(%FlatBufferModel{model: model}) do
+  def contains_edge_tpu_custom_op?(%FlatBufferModel{model: model}) do
     TFLiteElixir.Nif.coral_contains_edgetpu_custom_op(model)
   end
 
-  @spec edgeTpuDevices() :: [String.t()]
-  def edgeTpuDevices() do
+  @spec edge_tpu_devices() :: [String.t()]
+  def edge_tpu_devices() do
     TFLiteElixir.Nif.coral_edgetpu_devices()
   end
 
@@ -49,40 +49,40 @@ defmodule TFLiteElixir.Coral do
     The generic way to reference all devices (no assumption about device type):
         ":0", ":1", ":2", ":3", ":4", ":5".
   """
-  @spec getEdgeTpuContext() :: {:ok, reference()} | {:error, String.t()}
-  def getEdgeTpuContext() do
+  @spec get_edge_tpu_context() :: {:ok, reference()} | {:error, String.t()}
+  def get_edge_tpu_context() do
     TFLiteElixir.Nif.coral_get_edgetpu_context("", %{})
   end
 
-  deferror(getEdgeTpuContext())
+  deferror(get_edge_tpu_context())
 
-  @spec getEdgeTpuContext(String.t()) :: {:ok, reference()} | {:error, String.t()}
-  def getEdgeTpuContext(device) do
+  @spec get_edge_tpu_context(String.t()) :: {:ok, reference()} | {:error, String.t()}
+  def get_edge_tpu_context(device) do
     TFLiteElixir.Nif.coral_get_edgetpu_context(device, %{})
   end
 
-  deferror(getEdgeTpuContext(device))
+  deferror(get_edge_tpu_context(device))
 
-  @spec getEdgeTpuContext(String.t(), Map.t()) :: {:ok, reference()} | {:error, String.t()}
-  def getEdgeTpuContext(device, options) do
+  @spec get_edge_tpu_context(String.t(), Map.t()) :: {:ok, reference()} | {:error, String.t()}
+  def get_edge_tpu_context(device, options) do
     TFLiteElixir.Nif.coral_get_edgetpu_context(device, options)
   end
 
-  deferror(getEdgeTpuContext(device, options))
+  deferror(get_edge_tpu_context(device, options))
 
-  @spec makeEdgeTpuInterpreter(%FlatBufferModel{}, reference()) ::
+  @spec make_edge_tpu_interpreter(%FlatBufferModel{}, reference()) ::
           {:ok, reference()} | {:error, String.t()}
-  def makeEdgeTpuInterpreter(%FlatBufferModel{model: model}, edgetpu_context) do
+  def make_edge_tpu_interpreter(%FlatBufferModel{model: model}, edgetpu_context) do
     TFLiteElixir.Nif.coral_make_edgetpu_interpreter(model, edgetpu_context)
   end
 
-  deferror(makeEdgeTpuInterpreter(model, edgetpu_context))
+  deferror(make_edge_tpu_interpreter(model, edgetpu_context))
 
-  def dequantizeTensor(interpreter, tensor_index) do
+  def dequantize_tensor(interpreter, tensor_index) do
     TFLiteElixir.Nif.coral_dequantize_tensor(interpreter, tensor_index, nil)
   end
 
-  def dequantizeTensor(interpreter, tensor_index, as_type) do
+  def dequantize_tensor(interpreter, tensor_index, as_type) do
     as_type = map_type(as_type)
     TFLiteElixir.Nif.coral_dequantize_tensor(interpreter, tensor_index, as_type)
   end

--- a/lib/tflite_elixir/flat_buffer_model.ex
+++ b/lib/tflite_elixir/flat_buffer_model.ex
@@ -17,8 +17,8 @@ defmodule TFLiteElixir.FlatBufferModel do
   Note that if the tensorflow-lite library was compiled with `TFLITE_MCU`,
   then this function will always have return type `nif_error()`
   """
-  @spec buildFromFile(String.t()) :: %T{} | nif_error()
-  def buildFromFile(filename) when is_binary(filename) do
+  @spec build_from_file(String.t()) :: %T{} | nif_error()
+  def build_from_file(filename) when is_binary(filename) do
     with {:ok, model} <- TFLiteElixir.Nif.flatBufferModel_buildFromFile(filename) do
       %T{model: model}
     else
@@ -26,7 +26,7 @@ defmodule TFLiteElixir.FlatBufferModel do
     end
   end
 
-  deferror(buildFromFile(filename))
+  deferror(build_from_file(filename))
 
   @doc """
   Build model from caller owned memory buffer
@@ -42,8 +42,8 @@ defmodule TFLiteElixir.FlatBufferModel do
     However, we would have no way to release the copied memory because we couldn't
     identify if the `allocation_` borrows or owns that memory.
   """
-  @spec buildFromBuffer(binary()) :: %T{} | nif_error()
-  def buildFromBuffer(buffer) when is_binary(buffer) do
+  @spec build_from_buffer(binary()) :: %T{} | nif_error()
+  def build_from_buffer(buffer) when is_binary(buffer) do
     with {:ok, model} <- TFLiteElixir.Nif.flatBufferModel_buildFromBuffer(buffer) do
       %T{model: model}
     else
@@ -51,7 +51,7 @@ defmodule TFLiteElixir.FlatBufferModel do
     end
   end
 
-  deferror(buildFromBuffer(buffer))
+  deferror(build_from_buffer(buffer))
 
   @spec initialized(%T{}) :: bool() | nif_error()
   def initialized(%T{model: self}) when is_reference(self) do
@@ -71,24 +71,24 @@ defmodule TFLiteElixir.FlatBufferModel do
   in which case the actual required runtime might be greater than the
   reported minimum.
   """
-  @spec getMinimumRuntime(%T{}) :: String.t() | nif_error()
-  def getMinimumRuntime(%T{model: self}) when is_reference(self) do
+  @spec get_minimum_runtime(%T{}) :: String.t() | nif_error()
+  def get_minimum_runtime(%T{model: self}) when is_reference(self) do
     TFLiteElixir.Nif.flatBufferModel_getMinimumRuntime(self)
   end
 
-  deferror(getMinimumRuntime(self))
+  deferror(get_minimum_runtime(self))
 
   @doc """
   Return model metadata as a mapping of name & buffer strings.
 
   See Metadata table in TFLite schema.
   """
-  @spec readAllMetadata(%T{}) :: %{String.t() => String.t()} | nif_error()
-  def readAllMetadata(%T{model: self}) when is_reference(self) do
+  @spec read_all_metadata(%T{}) :: %{String.t() => String.t()} | nif_error()
+  def read_all_metadata(%T{model: self}) when is_reference(self) do
     TFLiteElixir.Nif.flatBufferModel_readAllMetadata(self)
   end
 
-  deferror(readAllMetadata(self))
+  deferror(read_all_metadata(self))
 
   @doc false
   @impl true
@@ -98,12 +98,12 @@ defmodule TFLiteElixir.FlatBufferModel do
 
   @impl true
   def fetch(self, :minimum_runtime) do
-    {:ok, getMinimumRuntime(self)}
+    {:ok, get_minimum_runtime(self)}
   end
 
   @impl true
   def fetch(self, :metadata) do
-    {:ok, readAllMetadata(self)}
+    {:ok, read_all_metadata(self)}
   end
 
   @impl true
@@ -125,8 +125,8 @@ defmodule TFLiteElixir.FlatBufferModel do
         to_doc(
           %{
             "initialized" => T.initialized(self),
-            "metadata" => T.readAllMetadata(self),
-            "minimum_runtime" => T.getMinimumRuntime(self)
+            "metadata" => T.read_all_metadata(self),
+            "minimum_runtime" => T.get_minimum_runtime(self)
           },
           opts
         ),

--- a/lib/tflite_elixir/interpreter.ex
+++ b/lib/tflite_elixir/interpreter.ex
@@ -47,7 +47,7 @@ defmodule TFLiteElixir.Interpreter do
   @spec new(String.t()) :: nif_resource_ok() | nif_error()
   def new(model_path) do
     with {:build_from_file, %FlatBufferModel{} = model} <-
-           {:build_from_file, FlatBufferModel.buildFromFile(model_path)},
+           {:build_from_file, FlatBufferModel.build_from_file(model_path)},
          {:builtin_resolver, {:ok, resolver}} <-
            {:builtin_resolver, TFLiteElixir.Ops.Builtin.BuiltinResolver.new()},
          {:interpreter_build, {:ok, builder}} <-

--- a/lib/tflite_elixir/interpreter.ex
+++ b/lib/tflite_elixir/interpreter.ex
@@ -57,7 +57,7 @@ defmodule TFLiteElixir.Interpreter do
          {:build_interpreter, :ok} <-
            {:build_interpreter, InterpreterBuilder.build(builder, interpreter)},
          {:allocate_tensors, :ok} <-
-           {:allocate_tensors, Interpreter.allocateTensors(interpreter)} do
+           {:allocate_tensors, Interpreter.allocate_tensors(interpreter)} do
       {:ok, interpreter}
     else
       error -> error
@@ -177,12 +177,12 @@ defmodule TFLiteElixir.Interpreter do
   @doc """
   Allocate memory for tensors in the graph
   """
-  @spec allocateTensors(reference()) :: :ok | nif_error()
-  def allocateTensors(self) when is_reference(self) do
+  @spec allocate_tensors(reference()) :: :ok | nif_error()
+  def allocate_tensors(self) when is_reference(self) do
     TFLiteElixir.Nif.interpreter_allocateTensors(self)
   end
 
-  deferror(allocateTensors(self))
+  deferror(allocate_tensors(self))
 
   @doc """
   Get the list of input tensors.
@@ -203,12 +203,12 @@ defmodule TFLiteElixir.Interpreter do
   if `inputs/1` returns `[42, 314]`, then `0` should be passed here to get the name of
   tensor `42`
   """
-  @spec getInputName(reference(), non_neg_integer()) :: {:ok, String.t()} | nif_error()
-  def getInputName(self, index) when is_reference(self) and index >= 0 do
+  @spec get_input_name(reference(), non_neg_integer()) :: {:ok, String.t()} | nif_error()
+  def get_input_name(self, index) when is_reference(self) and index >= 0 do
     TFLiteElixir.Nif.interpreter_getInputName(self, index)
   end
 
-  deferror(getInputName(self, index))
+  deferror(get_input_name(self, index))
 
   @doc """
   Fill data to the specified input tensor
@@ -258,12 +258,12 @@ defmodule TFLiteElixir.Interpreter do
 
   return a list of output tensor id
   """
-  @spec getOutputName(reference(), non_neg_integer()) :: {:ok, String.t()} | nif_error()
-  def getOutputName(self, index) when is_reference(self) and index >= 0 do
+  @spec get_output_name(reference(), non_neg_integer()) :: {:ok, String.t()} | nif_error()
+  def get_output_name(self, index) when is_reference(self) and index >= 0 do
     TFLiteElixir.Nif.interpreter_getOutputName(self, index)
   end
 
-  deferror(getOutputName(self, index))
+  deferror(get_output_name(self, index))
 
   @doc """
   Get the name of the input tensor
@@ -328,27 +328,27 @@ defmodule TFLiteElixir.Interpreter do
   ```elixir
   interpreter = Interpreter.new!()
   builder = InterpreterBuilder.new!(tflite model, op resolver)
-  InterpreterBuilder.setNumThreads(builder, ...)
+  InterpreterBuilder.set_num_threads(builder, ...)
   assert :ok == InterpreterBuilder.build!(builder, interpreter)
   ```
   """
-  @spec setNumThreads(reference(), integer()) :: :ok | nif_error()
-  def setNumThreads(self, num_threads) when is_integer(num_threads) and num_threads >= -1 do
+  @spec set_num_threads(reference(), integer()) :: :ok | nif_error()
+  def set_num_threads(self, num_threads) when is_integer(num_threads) and num_threads >= -1 do
     TFLiteElixir.Nif.interpreter_setNumThreads(self, num_threads)
   end
 
-  deferror(setNumThreads(self, num_threads))
+  deferror(set_num_threads(self, num_threads))
 
-  @spec getSignatureDefs(reference()) :: Map.t()
-  def getSignatureDefs(self) do
+  @spec get_signature_defs(reference()) :: Map.t()
+  def get_signature_defs(self) do
     TFLiteElixir.Nif.interpreter_get_signature_defs(self)
   end
 
-  deferror(getSignatureDefs(self))
+  deferror(get_signature_defs(self))
 
   @spec get_full_signature_list(reference()) :: Map.t()
   def get_full_signature_list(self) do
-    getSignatureDefs(self)
+    get_signature_defs(self)
   end
 
   deferror(get_full_signature_list(self))

--- a/lib/tflite_elixir/interpreter_builder.ex
+++ b/lib/tflite_elixir/interpreter_builder.ex
@@ -36,10 +36,10 @@ defmodule TFLiteElixir.InterpreterBuilder do
   Sets the number of CPU threads to use for the interpreter.
   Returns `true` on success, `{:error, reason}` on error.
   """
-  @spec setNumThreads(reference(), integer()) :: :ok | nif_error()
-  def setNumThreads(self, num_threads) when is_integer(num_threads) and num_threads >= -1 do
+  @spec set_num_threads(reference(), integer()) :: :ok | nif_error()
+  def set_num_threads(self, num_threads) when is_integer(num_threads) and num_threads >= -1 do
     TFLiteElixir.Nif.interpreterBuilder_setNumThreads(self, num_threads)
   end
 
-  deferror(setNumThreads(self, num_threads))
+  deferror(set_num_threads(self, num_threads))
 end

--- a/test/tflite_elixir_test.exs
+++ b/test/tflite_elixir_test.exs
@@ -13,18 +13,18 @@ defmodule TFLiteElixir.Test do
     resolver = TFLiteElixir.Ops.Builtin.BuiltinResolver.new!()
     builder = TFLiteElixir.InterpreterBuilder.new!(model, resolver)
     interpreter = TFLiteElixir.Interpreter.new!()
-    TFLiteElixir.InterpreterBuilder.setNumThreads!(builder, 2)
+    TFLiteElixir.InterpreterBuilder.set_num_threads!(builder, 2)
     :ok = TFLiteElixir.InterpreterBuilder.build!(builder, interpreter)
-    TFLiteElixir.Interpreter.setNumThreads!(interpreter, 2)
+    TFLiteElixir.Interpreter.set_num_threads!(interpreter, 2)
 
     # verify
     [0] = TFLiteElixir.Interpreter.inputs!(interpreter)
     [171] = TFLiteElixir.Interpreter.outputs!(interpreter)
 
     "map/TensorArrayStack/TensorArrayGatherV3" =
-      TFLiteElixir.Interpreter.getInputName!(interpreter, 0)
+      TFLiteElixir.Interpreter.get_input_name!(interpreter, 0)
 
-    "prediction" = TFLiteElixir.Interpreter.getOutputName!(interpreter, 0)
+    "prediction" = TFLiteElixir.Interpreter.get_output_name!(interpreter, 0)
 
     input_tensor =
       %TFLiteElixir.TFLiteTensor{
@@ -48,7 +48,7 @@ defmodule TFLiteElixir.Test do
     {:u, 8} = TFLiteElixir.TFLiteTensor.type!(output_tensor)
 
     # run forwarding
-    :ok = TFLiteElixir.Interpreter.allocateTensors!(interpreter)
+    :ok = TFLiteElixir.Interpreter.allocate_tensors!(interpreter)
     TFLiteElixir.Interpreter.input_tensor!(interpreter, 0, input_data)
     TFLiteElixir.Interpreter.invoke!(interpreter)
     output_data = TFLiteElixir.Interpreter.output_tensor!(interpreter, 0)

--- a/test/tflite_elixir_test.exs
+++ b/test/tflite_elixir_test.exs
@@ -54,7 +54,7 @@ defmodule TFLiteElixir.Test do
     output_data = TFLiteElixir.Interpreter.output_tensor!(interpreter, 0)
     true = expected_out == output_data
 
-    if print_state, do: TFLiteElixir.printInterpreterState(interpreter)
+    if print_state, do: TFLiteElixir.print_interpreter_state(interpreter)
     :ok
   end
 

--- a/test/tflite_elixir_test.exs
+++ b/test/tflite_elixir_test.exs
@@ -87,7 +87,7 @@ defmodule TFLiteElixir.Test do
     test "Contains EdgeTpu Custom Op" do
       filename = Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant.tflite"])
       model = TFLiteElixir.FlatBufferModel.build_from_buffer!(File.read!(filename))
-      ret = TFLiteElixir.Coral.containsEdgeTpuCustomOp?(model)
+      ret = TFLiteElixir.Coral.contains_edge_tpu_custom_op?(model)
 
       :ok =
         case ret do
@@ -106,7 +106,7 @@ defmodule TFLiteElixir.Test do
         Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant_edgetpu.tflite"])
 
       model = TFLiteElixir.FlatBufferModel.build_from_buffer!(File.read!(filename))
-      ret = TFLiteElixir.Coral.containsEdgeTpuCustomOp?(model)
+      ret = TFLiteElixir.Coral.contains_edge_tpu_custom_op?(model)
 
       :ok =
         case ret do

--- a/test/tflite_elixir_test.exs
+++ b/test/tflite_elixir_test.exs
@@ -6,10 +6,10 @@ defmodule TFLiteElixir.Test do
              is_boolean(print_state) do
     # build interpreter
     %{"TFLITE_METADATA" => <<28>>, "min_runtime_version" => "1.5.0"} =
-      TFLiteElixir.FlatBufferModel.readAllMetadata!(model)
+      TFLiteElixir.FlatBufferModel.read_all_metadata!(model)
 
     true = TFLiteElixir.FlatBufferModel.initialized!(model)
-    "1.5.0" = TFLiteElixir.FlatBufferModel.getMinimumRuntime!(model)
+    "1.5.0" = TFLiteElixir.FlatBufferModel.get_minimum_runtime!(model)
     resolver = TFLiteElixir.Ops.Builtin.BuiltinResolver.new!()
     builder = TFLiteElixir.InterpreterBuilder.new!(model, resolver)
     interpreter = TFLiteElixir.Interpreter.new!()
@@ -62,7 +62,7 @@ defmodule TFLiteElixir.Test do
     filename = Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant.tflite"])
     input_data = Path.join([__DIR__, "test_data", "parrot.bin"]) |> File.read!()
     expected_out = Path.join([__DIR__, "test_data", "parrot-expected-out.bin"]) |> File.read!()
-    model = TFLiteElixir.FlatBufferModel.buildFromFile!(filename)
+    model = TFLiteElixir.FlatBufferModel.build_from_file!(filename)
     :ok = verify_loaded_model(model, input_data, expected_out, true)
   end
 
@@ -79,14 +79,14 @@ defmodule TFLiteElixir.Test do
     filename = Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant.tflite"])
     input_data = Path.join([__DIR__, "test_data", "parrot.bin"]) |> File.read!()
     expected_out = Path.join([__DIR__, "test_data", "parrot-expected-out.bin"]) |> File.read!()
-    model = TFLiteElixir.FlatBufferModel.buildFromBuffer!(File.read!(filename))
+    model = TFLiteElixir.FlatBufferModel.build_from_buffer!(File.read!(filename))
     :ok = verify_loaded_model(model, input_data, expected_out, false)
   end
 
   with {:module, TFLiteElixir.Coral} <- Code.ensure_compiled(TFLiteElixir.Coral) do
     test "Contains EdgeTpu Custom Op" do
       filename = Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant.tflite"])
-      model = TFLiteElixir.FlatBufferModel.buildFromBuffer!(File.read!(filename))
+      model = TFLiteElixir.FlatBufferModel.build_from_buffer!(File.read!(filename))
       ret = TFLiteElixir.Coral.containsEdgeTpuCustomOp?(model)
 
       :ok =
@@ -105,7 +105,7 @@ defmodule TFLiteElixir.Test do
       filename =
         Path.join([__DIR__, "test_data", "mobilenet_v2_1.0_224_inat_bird_quant_edgetpu.tflite"])
 
-      model = TFLiteElixir.FlatBufferModel.buildFromBuffer!(File.read!(filename))
+      model = TFLiteElixir.FlatBufferModel.build_from_buffer!(File.read!(filename))
       ret = TFLiteElixir.Coral.containsEdgeTpuCustomOp?(model)
 
       :ok =


### PR DESCRIPTION
This is an attempt at making consistent the names of Elixir functions.

Currently function names are inconsistent: some camelCase; some snake_case. Idiomatically Elixir functions are named with snake case. So we want to standardize on snake case Elixir functions.

One thing we need to decide on is the boundary between C++ and Elixir. For this iteration, I focus on Elixir API, leaving alone the `TFLiteElixir.Nif` functions.

In the future, the names of `TFLiteElixir.Nif` functions can be cleaned up as well, but since they are private, we can work on them anytime.