### PR TITLE
update examples and tasks with v0.1.4

### DIFF
--- a/examples/super_resolution.livemd
+++ b/examples/super_resolution.livemd
@@ -1,16 +1,6 @@
 # Super resolution
 
 ```elixir
-# # a quick fix for the free tier livebook session
-# ## allocate 4GB? swap
-# System.cmd("fallocate", ["-l", "4G", "/swap"])
-# System.cmd("chmod", ["400", "/swap"])
-# System.cmd("mkswap", ["/swap"])
-# System.cmd("swapon", ["/swap"])
-# ## need unzip to unzip the source code
-# System.cmd("apt", ["update", "-q", "-y"])
-# System.cmd("apt", ["install", "-y", "unzip", "python3", "cmake"])
-
 Mix.install([
   {:tflite_elixir, "~> 0.1.4"},
   {:evision, "~> 0.1.8"},
@@ -56,16 +46,16 @@ data_files = %{
 ## Alias modules
 
 ```elixir
-alias Evision, as: OpenCV
+alias Evision, as: Cv
 alias TFLiteElixir, as: TFLite
 ```
 
 ## Generate a super resolution image using TensorFlow Lite
 
 ```elixir
-lr = OpenCV.imread(data_files.test_img)
-lr = OpenCV.cvtColor(lr, OpenCV.Constant.cv_COLOR_BGR2RGB())
-lr = OpenCV.Mat.to_nx(lr)
+lr = Cv.imread(data_files.test_img)
+lr = Cv.cvtColor(lr, Cv.Constant.cv_COLOR_BGR2RGB())
+lr = Cv.Mat.to_nx(lr)
 lr = Nx.new_axis(lr, 0)
 lr = Nx.as_type(lr, {:f, 32})
 
@@ -98,17 +88,17 @@ sr =
 
 ```elixir
 data_files.test_img
-|> OpenCV.imread()
-|> then(&OpenCV.imencode(".jpeg", &1))
+|> Cv.imread()
+|> then(&Cv.imencode(".jpeg", &1))
 |> IO.iodata_to_binary()
 |> Kino.Image.new(:jpeg)
 ```
 
 ```elixir
 sr
-|> OpenCV.Mat.from_nx()
-|> OpenCV.cvtColor(OpenCV.Constant.cv_COLOR_RGB2BGR())
-|> then(&OpenCV.imencode(".jpeg", &1))
+|> Cv.Mat.from_nx()
+|> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR())
+|> then(&Cv.imencode(".jpeg", &1))
 |> IO.iodata_to_binary()
 |> Kino.Image.new(:jpeg)
 ```

--- a/examples/super_resolution.livemd
+++ b/examples/super_resolution.livemd
@@ -12,7 +12,7 @@
 # System.cmd("apt", ["install", "-y", "unzip", "python3", "cmake"])
 
 Mix.install([
-  {:tflite_elixir, "~> 0.1.3"},
+  {:tflite_elixir, "~> 0.1.4"},
   {:evision, "~> 0.1.8"},
   {:nx, "~> 0.5.0"},
   {:kino, "~> 0.8.0"},

--- a/examples/tflite_benchmark_densenet.livemd
+++ b/examples/tflite_benchmark_densenet.livemd
@@ -251,7 +251,7 @@ defmodule ClassifyImage do
   end
 
   defp make_interpreter(model, _num_jobs, true, tpu_context) do
-    TFLiteElixir.Coral.makeEdgeTpuInterpreter!(model, tpu_context)
+    TFLiteElixir.Coral.make_edge_tpu_interpreter!(model, tpu_context)
   end
 
   defp get_scores(output_data, %TFTensor{type: dtype = {:u, _}} = output_tensor) do

--- a/examples/tflite_benchmark_densenet.livemd
+++ b/examples/tflite_benchmark_densenet.livemd
@@ -84,10 +84,10 @@ defmodule ClassifyImage do
   Code based on [classify_image.py](https://github.com/google-coral/pycoral/blob/master/examples/classify_image.py)
   """
 
-  alias TFLiteElixir.Interpreter, as: Interpreter
-  alias TFLiteElixir.InterpreterBuilder, as: InterpreterBuilder
-  alias TFLiteElixir.TFLiteTensor, as: TFTensor
-  alias TFLiteElixir.FlatBufferModel, as: FlatBufferModel
+  alias TFLiteElixir.Interpreter
+  alias TFLiteElixir.InterpreterBuilder
+  alias TFLiteElixir.TFLiteTensor
+  alias TFLiteElixir.FlatBufferModel
 
   def run(args) do
     default_values = [
@@ -172,7 +172,7 @@ defmodule ClassifyImage do
       |> Nx.as_type(:f32)
       |> Nx.to_binary()
     end
-    |> then(&TFTensor.set_data!(input_tensor, &1))
+    |> then(&TFLiteTensor.set_data!(input_tensor, &1))
 
     IO.puts("----INFERENCE TIME----")
 
@@ -254,7 +254,7 @@ defmodule ClassifyImage do
     TFLiteElixir.Coral.make_edge_tpu_interpreter!(model, tpu_context)
   end
 
-  defp get_scores(output_data, %TFTensor{type: dtype = {:u, _}} = output_tensor) do
+  defp get_scores(output_data, %TFLiteTensor{type: dtype = {:u, _}} = output_tensor) do
     scale = Nx.tensor(output_tensor.quantization_params.scale)
     zero_point = Nx.tensor(output_tensor.quantization_params.zero_point)
 
@@ -264,7 +264,7 @@ defmodule ClassifyImage do
     |> Nx.multiply(scale)
   end
 
-  defp get_scores(output_data, %TFTensor{type: dtype = {:s, _}} = output_tensor) do
+  defp get_scores(output_data, %TFLiteTensor{type: dtype = {:s, _}} = output_tensor) do
     [scale] = output_tensor.quantization_params.scale
     [zero_point] = output_tensor.quantization_params.zero_point
 
@@ -274,7 +274,7 @@ defmodule ClassifyImage do
     |> Nx.multiply(scale)
   end
 
-  defp get_scores(output_data, %TFTensor{type: dtype}) do
+  defp get_scores(output_data, %TFLiteTensor{type: dtype}) do
     Nx.from_binary(output_data, dtype)
   end
 end

--- a/examples/tpu.livemd
+++ b/examples/tpu.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:tflite_elixir, "~> 0.1.3"},
+  {:tflite_elixir, "~> 0.1.4"},
   {:nx, "~> 0.5.0"},
   {:req, "~> 0.3.0"},
   {:stb_image, "~> 0.6.0"}
@@ -106,7 +106,7 @@ defmodule ClassifyImage do
 
     tpu_context =
       if args[:use_tpu] do
-        TFLiteElixir.Coral.getEdgeTpuContext!(args[:tpu])
+        TFLiteElixir.Coral.get_edge_tpu_context!(args[:tpu])
       else
         nil
       end
@@ -224,14 +224,14 @@ defmodule ClassifyImage do
     resolver = TFLiteElixir.Ops.Builtin.BuiltinResolver.new!()
     builder = InterpreterBuilder.new!(model, resolver)
     interpreter = Interpreter.new!()
-    InterpreterBuilder.setNumThreads!(builder, num_jobs)
+    InterpreterBuilder.set_num_threads!(builder, num_jobs)
     :ok = InterpreterBuilder.build!(builder, interpreter)
-    Interpreter.setNumThreads!(interpreter, num_jobs)
+    Interpreter.set_num_threads!(interpreter, num_jobs)
     interpreter
   end
 
   defp make_interpreter(model, _num_jobs, true, tpu_context) do
-    TFLiteElixir.Coral.makeEdgeTpuInterpreter!(model, tpu_context)
+    TFLiteElixir.Coral.make_edge_tpu_interpreter!(model, tpu_context)
   end
 
   defp get_scores(output_data, %TFLiteTensor{type: dtype = {:u, _}} = output_tensor) do

--- a/lib/tasks/classify_image.ex
+++ b/lib/tasks/classify_image.ex
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.ClassifyImage do
 
     tpu_context =
       if args[:use_tpu] do
-        TFLiteElixir.Coral.getEdgeTpuContext!(args[:tpu])
+        TFLiteElixir.Coral.get_edge_tpu_context!(args[:tpu])
       else
         nil
       end
@@ -211,7 +211,7 @@ defmodule Mix.Tasks.ClassifyImage do
   end
 
   defp make_interpreter(model, _num_jobs, true, tpu_context) do
-    TFLiteElixir.Coral.makeEdgeTpuInterpreter!(model, tpu_context)
+    TFLiteElixir.Coral.make_edge_tpu_interpreter!(model, tpu_context)
   end
 
   defp get_scores(output_data, %TFTensor{type: dtype = {:u, _}} = output_tensor) do

--- a/lib/tasks/list_edgetpu.ex
+++ b/lib/tasks/list_edgetpu.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.ListEdgetpu do
 
   @shortdoc "List all available Edge Tpu"
   def run(_) do
-    case TFLiteElixir.Coral.edgeTpuDevices() do
+    case TFLiteElixir.Coral.edge_tpu_devices() do
       {:error, error} ->
         IO.puts("Error: #{error}")
 

--- a/lib/tflite_elixir/coral.ex
+++ b/lib/tflite_elixir/coral.ex
@@ -7,7 +7,7 @@ defmodule TFLiteElixir.Coral do
     TFLiteElixir.Nif.coral_contains_edgetpu_custom_op(model)
   end
 
-  @spec edge_tpu_devices() :: [String.t()]
+  @spec edge_tpu_devices() :: [String.t()] | {:error, String.t()}
   def edge_tpu_devices() do
     TFLiteElixir.Nif.coral_edgetpu_devices()
   end


### PR DESCRIPTION
### Description

Our Mix tasks still uses pre-v0.1.4 functions. This PR fixes them.

### Changes

- use v0.1.4 functions in tasks
- use v0.1.4 functions in examples

### Notes

Related PR: https://github.com/cocoa-xu/tflite_elixir/pull/21