### PR TITLE
doc: artistic-style-transfer example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,9 @@ Generate a super resolution image from a low resolution image.
 
 ## Inference on TPU (Coral)
 [![Run in Livebook](https://livebook.dev/badge/v1/gray.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fcocoa-xu%2Ftflite_elixir%2Fblob%2Fmain%2Fexamples%2Ftpu.livemd)
+
+## Style transfer
+
+Apply any styles on an input image to create a new artistic image.
+
+[![Run in Livebook](https://livebook.dev/badge/v1/gray.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fcocoa-xu%2Ftflite_elixir%2Fblob%2Fmain%2Fexamples%2Fartistic_style_transfer.livemd)

--- a/examples/artistic_style_transfer.livemd
+++ b/examples/artistic_style_transfer.livemd
@@ -98,41 +98,52 @@ alias TFLiteElixir, as: TFLite
 ```elixir
 # Function to load an image from a file, and add a batch dimension.
 load_img = fn path_to_img ->
-  %Nx.Tensor{} =
+  %Cv.Mat{} =
     path_to_img
     |> Cv.imread()
     |> Cv.cvtColor(Cv.Constant.cv_COLOR_BGR2RGB(), dstCn: 3)
+end
+
+# Function to pre-process by resizing an central cropping it.
+preprocess_image = fn image, target_dim ->
+  # Resize the image so that the shorter dimension becomes 256px.
+  {h, w, _} = image.shape
+
+  {resize_h, resize_w} =
+    if h > w do
+      scale = target_dim / w
+      {trunc(h * scale), target_dim}
+    else
+      scale = target_dim / h
+      {target_dim, trunc(w * scale)}
+    end
+
+  image = Cv.resize(image, {resize_h, resize_w})
+
+  # Central crop the image.
+  {centre_h, centre_w} = {resize_h / 2, resize_w / 2}
+  x = trunc(centre_w - target_dim / 2)
+  y = trunc(centre_h - target_dim / 2)
+  new_shape = {y, x, target_dim, target_dim}
+
+  %Nx.Tensor{} =
+    image
+    |> Cv.Mat.roi(new_shape)
     |> Cv.Mat.to_nx()
     |> Nx.new_axis(0)
     |> Nx.as_type({:f, 32})
 end
 
-# Function to pre-process by resizing an central cropping it.
-preprocess_image = fn image, target_dim ->
-  nil
-  # TODO: convert python to elixir
-  #
-  # # Resize the image so that the shorter dimension becomes 256px.
-  # shape = tf.cast(tf.shape(image)[1:-1], tf.float32)
-  # short_dim = min(shape)
-  # scale = target_dim / short_dim
-  # new_shape = tf.cast(shape * scale, tf.int32)
-  # image = tf.image.resize(image, new_shape)
-
-  # # Central crop the image.
-  # image = tf.image.resize_with_crop_or_pad(image, target_dim, target_dim)
-end
-
 # Load the input images.
-content_image = %Nx.Tensor{} = load_img.(data_files.content)
-style_image = %Nx.Tensor{} = load_img.(data_files.style)
+%Cv.Mat{} = content_image = load_img.(data_files.content)
+%Cv.Mat{} = style_image = load_img.(data_files.style)
 
-# # Preprocess the input images.
-# preprocessed_content_image = preprocess_image.(content_image, 384)
-# preprocessed_style_image = preprocess_image.(style_image, 256)
+# Preprocess the input images.
+preprocessed_content_image = preprocess_image.(content_image, 384)
+preprocessed_style_image = preprocess_image.(style_image, 256)
 
-# IO.puts("Style Image Shape:", preprocessed_style_image.shape)
-# IO.puts("Content Image Shape:", preprocessed_content_image.shape)
+IO.puts("Style Image Shape: #{inspect(preprocessed_style_image.shape)}")
+IO.puts("Content Image Shape: #{inspect(preprocessed_content_image.shape)}")
 ```
 
 ## Visualize the inputs

--- a/examples/artistic_style_transfer.livemd
+++ b/examples/artistic_style_transfer.livemd
@@ -80,7 +80,7 @@ alias TFLiteElixir.TFLiteTensor
   resize it.
 
 ```elixir
-# Function to load an image from a file, and add a batch dimension.
+# Load an image from a file, and add a batch dimension.
 load_image = fn path_to_img ->
   path_to_img
   |> Cv.imread()
@@ -152,89 +152,97 @@ preprocessed_style.image
 
 ### Style prediction
 
-* Run style prediction on preprocessed style image.
-
 ```elixir
-# Load the model.
-{:ok, interpreter} = TFLite.Interpreter.new(data_files.style_predict)
+# Run style prediction on preprocessed style image.
+run_style_predict = fn <<_::binary>> = preprocessed_style_data ->
+  # Load the model.
+  {:ok, interpreter} = TFLite.Interpreter.new(data_files.style_predict)
 
-# Get input and output tensors.
-{:ok, _input_tensors} = TFLite.Interpreter.inputs(interpreter)
-{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
+  # Get input and output tensors.
+  {:ok, _input_tensors} = TFLite.Interpreter.inputs(interpreter)
+  {:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
 
-# Run the model
-TFLite.Interpreter.input_tensor(interpreter, 0, Nx.to_binary(preprocessed_style.tensor))
-TFLite.Interpreter.invoke(interpreter)
+  # Run the model
+  TFLite.Interpreter.input_tensor(interpreter, 0, preprocessed_style_data)
+  TFLite.Interpreter.invoke(interpreter)
 
-# Calculate style bottleneck for the preprocessed style image.
-style_bottleneck = TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
-
-style_bottleneck_data =
-  style_bottleneck
+  # Calculate style bottleneck for the preprocessed style image.
+  TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
   |> TFLiteTensor.to_nx(backend: Nx.BinaryBackend)
-  |> Nx.to_binary()
+end
+
+style_bottleneck = run_style_predict.(Nx.to_binary(preprocessed_style.tensor))
 
 IO.puts(["Style Bottleneck Shape: ", inspect(style_bottleneck.shape)])
 ```
 
 ### Style transform
 
-* Run style transform on preprocessed style image
-
 ```elixir
-# Load the model.
-{:ok, interpreter} = TFLite.Interpreter.new(data_files.style_transform)
+# Run style transform on preprocessed style image.
+run_style_transform = fn <<_::binary>> = style_bottleneck_data,
+                         <<_::binary>> = preprocessed_content_data ->
+  # Load the model.
+  {:ok, interpreter} = TFLite.Interpreter.new(data_files.style_transform)
 
-# Get input and output tensors.
-{:ok, input_tensors} = TFLite.Interpreter.inputs(interpreter)
-{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
+  # Get input and output tensors.
+  {:ok, _input_tensors} = TFLite.Interpreter.inputs(interpreter)
+  {:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
 
-# Run the model.
-TFLite.Interpreter.input_tensor(interpreter, 0, Nx.to_binary(preprocessed_content.tensor))
-TFLite.Interpreter.input_tensor(interpreter, 1, style_bottleneck_data)
-TFLite.Interpreter.invoke(interpreter)
+  # Run the model.
+  TFLite.Interpreter.input_tensor(interpreter, 0, preprocessed_content_data)
+  TFLite.Interpreter.input_tensor(interpreter, 1, style_bottleneck_data)
+  TFLite.Interpreter.invoke(interpreter)
 
-# Transform content image.
-{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
-{:ok, output_data} = TFLite.Interpreter.output_tensor(interpreter, 0)
-out_tensor = TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
-[1 | shape] = TFLite.TFLiteTensor.dims(out_tensor)
-type = TFLite.TFLiteTensor.type(out_tensor)
+  # Transform content image.
+  out_tensor = TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
+  [1 | shape] = TFLite.TFLiteTensor.dims(out_tensor)
 
-# Visualize the output.
-out_tensor
-|> TFLiteTensor.to_nx(backend: Nx.BinaryBackend)
-# Change the range from [0..1] to [0..255]
-|> Nx.multiply(255)
-|> Nx.reshape(List.to_tuple(shape))
-|> Nx.as_type({:u, 8})
-|> Cv.Mat.from_nx_2d()
-|> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR())
+  out_tensor
+  |> TFLiteTensor.to_nx(backend: Nx.BinaryBackend)
+  # Change the range from [0..1] to [0..255]
+  |> Nx.multiply(255)
+  |> Nx.reshape(List.to_tuple(shape))
+  |> Nx.as_type({:u, 8})
+  |> Cv.Mat.from_nx_2d()
+  |> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR())
+end
+
+# Stylize the content image using the style bottleneck.
+_stylized_image =
+  run_style_transform.(
+    Nx.to_binary(style_bottleneck),
+    Nx.to_binary(preprocessed_content.tensor)
+  )
 ```
 
 ### Style blending
 
 ```elixir
-# # Calculate style bottleneck of the content image.
-# style_bottleneck_content = run_style_predict(
-#   preprocess_image(content_image, 256)
-# )
+# Calculate style bottleneck of the content image.
+style_bottleneck_content =
+  preprocess_image.(content_image, 256).tensor
+  |> Nx.to_binary()
+  |> run_style_predict.()
 ```
 
 ```elixir
-# # Define content blending ratio between [0..1].
-# # 0.0: 0% style extracts from content image.
-# # 1.0: 100% style extracted from content image.
-# content_blending_ratio = 0.5
+# Define content blending ratio between [0..1].
+# 0.0: 0% style extracts from content image.
+# 1.0: 100% style extracted from content image.
+content_blending_ratio = 0.5
 
-# # Blend the style bottleneck of style image and content image
-# style_bottleneck_blended = content_blending_ratio * style_bottleneck_content \
-#                            + (1 - content_blending_ratio) * style_bottleneck
+# Blend the style bottleneck of style image and content image
+style_bottleneck_blended =
+  Nx.add(
+    Nx.multiply(content_blending_ratio, style_bottleneck_content),
+    Nx.multiply(1 - content_blending_ratio, style_bottleneck)
+  )
 
-# # Stylize the content image using the style bottleneck.
-# stylized_image_blended = run_style_transform(style_bottleneck_blended,
-#                                              preprocessed_content_image)
-
-# # Visualize the output.
-# imshow(stylized_image_blended, 'Blended Stylized Image')
+# Stylize the content image using the style bottleneck.
+stylized_image_blended =
+  run_style_transform.(
+    Nx.to_binary(style_bottleneck_blended),
+    Nx.to_binary(preprocessed_content.tensor)
+  )
 ```

--- a/examples/artistic_style_transfer.livemd
+++ b/examples/artistic_style_transfer.livemd
@@ -126,12 +126,17 @@ preprocess_image = fn image, target_dim ->
   y = trunc(centre_h - target_dim / 2)
   new_shape = {y, x, target_dim, target_dim}
 
-  %Nx.Tensor{} =
-    image
-    |> Cv.Mat.roi(new_shape)
+  cropped_image = Cv.Mat.roi(image, new_shape)
+  tensor =
+    cropped_image
     |> Cv.Mat.to_nx()
     |> Nx.new_axis(0)
     |> Nx.as_type({:f, 32})
+
+  %{
+    :cropped => Cv.cvtColor(cropped_image, Cv.Constant.cv_COLOR_RGB2BGR()),
+    :tensor => tensor
+  }
 end
 
 # Load the input images.
@@ -142,26 +147,20 @@ end
 preprocessed_content_image = preprocess_image.(content_image, 384)
 preprocessed_style_image = preprocess_image.(style_image, 256)
 
-IO.puts("Style Image Shape: #{inspect(preprocessed_style_image.shape)}")
-IO.puts("Content Image Shape: #{inspect(preprocessed_content_image.shape)}")
+IO.puts("Style Image Shape: #{inspect(preprocessed_style_image.tensor.shape)}")
+IO.puts("Content Image Shape: #{inspect(preprocessed_content_image.tensor.shape)}")
 ```
 
 ## Visualize the inputs
 
 ```elixir
-# def imshow(image, title=None):
-#   if len(image.shape) > 3:
-#     image = tf.squeeze(image, axis=0)
+IO.puts("Content Image")
+preprocessed_content_image.cropped
+```
 
-#   plt.imshow(image)
-#   if title:
-#     plt.title(title)
-
-# plt.subplot(1, 2, 1)
-# imshow(preprocessed_content_image, 'Content Image')
-
-# plt.subplot(1, 2, 2)
-# imshow(preprocessed_style_image, 'Style Image')
+```elixir
+IO.puts("Style Image")
+preprocessed_style_image.cropped
 ```
 
 ## Run style transfer with TensorFlow Lite

--- a/examples/artistic_style_transfer.livemd
+++ b/examples/artistic_style_transfer.livemd
@@ -2,8 +2,8 @@
 
 ```elixir
 Mix.install([
-  {:tflite_elixir, "~> 0.1.4"},
-  {:evision, "~> 0.1.8"},
+  {:tflite_elixir, "0.1.5"},
+  {:evision, "0.1.29"},
   {:kino, "~> 0.8.0"},
   {:req, "~> 0.3.0"}
 ])
@@ -12,10 +12,9 @@ Mix.install([
 ## Introduction
 
 One of the most exciting developments in deep learning to come out recently is
-[artistic style transfer](https://arxiv.org/abs/1508.06576), or the ability to
-create a new image, known as a
-[pastiche](https://en.wikipedia.org/wiki/Pastiche), based on two input images:
-one representing the artistic style and one representing the content.
+[artistic style transfer](https://arxiv.org/abs/1508.06576), or the ability to create a new image, known as a
+[pastiche](https://en.wikipedia.org/wiki/Pastiche), based on two input images: one representing the artistic style and
+one representing the content.
 
 Using this technique, we can generate beautiful new artworks in a range of
 styles.
@@ -30,8 +29,7 @@ This Artistic Style Transfer model consists of two submodels:
 
 1. **Style Prediciton Model**: A MobilenetV2-based neural network that takes an
    input style image to a 100-dimension style bottleneck vector.
-2. **Style Transform Model**: A neural network that takes apply a style
-   bottleneck vector to a content image and creates a stylized image.
+2. **Style Transform Model**: A neural network that takes apply a style bottleneck vector to a content image and creates a stylized image.
 
 ## Download data files
 
@@ -45,37 +43,22 @@ downloads_dir = System.tmp_dir!()
 
 download = fn url ->
   save_as = Path.join(downloads_dir, URI.encode_www_form(url))
-
-  unless File.exists?(save_as) do
-    %{status: 200} = Req.get!(url, output: save_as)
-  end
-
+  unless File.exists?(save_as), do: Req.get!(url, output: save_as)
   save_as
 end
 
 data_files =
   [
-    {
-      :content,
-      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/belfry-2611573_1280.jpg"
-    },
-    {
-      :style,
-      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/style23.jpg"
-    },
-    {
-      :style_predict,
-      "https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/int8/prediction/1?lite-format=tflite"
-    },
-    {
-      :style_transform,
+    content:
+      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/belfry-2611573_1280.jpg",
+    style:
+      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/style23.jpg",
+    style_predict:
+      "https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/int8/prediction/1?lite-format=tflite",
+    style_transform:
       "https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/int8/transfer/1?lite-format=tflite"
-    }
   ]
-  |> Enum.map(fn {key, url} ->
-    Task.async(fn -> {key, download.(url)} end)
-  end)
-  |> Task.await_many(:timer.seconds(30))
+  |> Enum.map(fn {key, url} -> {key, download.(url)} end)
   |> Map.new()
 ```
 
@@ -84,6 +67,7 @@ data_files =
 ```elixir
 alias Evision, as: Cv
 alias TFLiteElixir, as: TFLite
+alias TFLiteElixir.TFLiteTensor
 ```
 
 ## Pre-process the inputs
@@ -97,11 +81,10 @@ alias TFLiteElixir, as: TFLite
 
 ```elixir
 # Function to load an image from a file, and add a batch dimension.
-load_img = fn path_to_img ->
-  %Cv.Mat{} =
-    path_to_img
-    |> Cv.imread()
-    |> Cv.cvtColor(Cv.Constant.cv_COLOR_BGR2RGB(), dstCn: 3)
+load_image = fn path_to_img ->
+  path_to_img
+  |> Cv.imread()
+  |> Cv.cvtColor(Cv.Constant.cv_COLOR_BGR2RGB(), dstCn: 3)
 end
 
 # Function to pre-process by resizing an central cropping it.
@@ -125,101 +108,108 @@ preprocess_image = fn image, target_dim ->
   x = trunc(centre_w - target_dim / 2)
   y = trunc(centre_h - target_dim / 2)
   new_shape = {y, x, target_dim, target_dim}
-
   cropped_image = Cv.Mat.roi(image, new_shape)
-  tensor =
-    cropped_image
-    |> Cv.Mat.to_nx()
-    |> Nx.new_axis(0)
-    |> Nx.as_type({:f, 32})
 
   %{
-    :cropped => Cv.cvtColor(cropped_image, Cv.Constant.cv_COLOR_RGB2BGR()),
-    :tensor => tensor
+    image:
+      cropped_image
+      |> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR()),
+    tensor:
+      cropped_image
+      |> Cv.Mat.to_nx(Nx.BinaryBackend)
+      |> Nx.new_axis(0)
+      |> Nx.as_type({:f, 32})
+      # Change the range from [0..255] to [0..1]
+      |> Nx.divide(255)
   }
 end
 
 # Load the input images.
-%Cv.Mat{} = content_image = load_img.(data_files.content)
-%Cv.Mat{} = style_image = load_img.(data_files.style)
+%Cv.Mat{} = content_image = load_image.(data_files.content)
+%Cv.Mat{} = style_image = load_image.(data_files.style)
 
 # Preprocess the input images.
-preprocessed_content_image = preprocess_image.(content_image, 384)
-preprocessed_style_image = preprocess_image.(style_image, 256)
+%{} = preprocessed_content = preprocess_image.(content_image, 384)
+%{} = preprocessed_style = preprocess_image.(style_image, 256)
 
-IO.puts("Style Image Shape: #{inspect(preprocessed_style_image.tensor.shape)}")
-IO.puts("Content Image Shape: #{inspect(preprocessed_content_image.tensor.shape)}")
+IO.puts(["Style Image Shape: ", inspect(preprocessed_style.tensor.shape)])
+IO.puts(["Content Image Shape: ", inspect(preprocessed_content.tensor.shape)])
 ```
 
 ## Visualize the inputs
 
 ```elixir
 IO.puts("Content Image")
-preprocessed_content_image.cropped
+preprocessed_content.image
 ```
 
 ```elixir
 IO.puts("Style Image")
-preprocessed_style_image.cropped
+preprocessed_style.image
 ```
 
 ## Run style transfer with TensorFlow Lite
 
 ### Style prediction
 
+* Run style prediction on preprocessed style image.
+
 ```elixir
-# # Function to run style prediction on preprocessed style image.
-# def run_style_predict(preprocessed_style_image):
-#   # Load the model.
-#   interpreter = tf.lite.Interpreter(model_path=style_predict_path)
+# Load the model.
+{:ok, interpreter} = TFLite.Interpreter.new(data_files.style_predict)
 
-#   # Set model input.
-#   interpreter.allocate_tensors()
-#   input_details = interpreter.get_input_details()
-#   interpreter.set_tensor(input_details[0]["index"], preprocessed_style_image)
+# Get input and output tensors.
+{:ok, _input_tensors} = TFLite.Interpreter.inputs(interpreter)
+{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
 
-#   # Calculate style bottleneck.
-#   interpreter.invoke()
-#   style_bottleneck = interpreter.tensor(
-#       interpreter.get_output_details()[0]["index"]
-#       )()
+# Run the model
+TFLite.Interpreter.input_tensor(interpreter, 0, Nx.to_binary(preprocessed_style.tensor))
+TFLite.Interpreter.invoke(interpreter)
 
-#   return style_bottleneck
+# Calculate style bottleneck for the preprocessed style image.
+style_bottleneck = TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
 
-# # Calculate style bottleneck for the preprocessed style image.
-# style_bottleneck = run_style_predict(preprocessed_style_image)
-# print('Style Bottleneck Shape:', style_bottleneck.shape)
+style_bottleneck_data =
+  style_bottleneck
+  |> TFLiteTensor.to_nx(backend: Nx.BinaryBackend)
+  |> Nx.to_binary()
+
+IO.puts(["Style Bottleneck Shape: ", inspect(style_bottleneck.shape)])
 ```
 
 ### Style transform
 
+* Run style transform on preprocessed style image
+
 ```elixir
-# # Run style transform on preprocessed style image
-# def run_style_transform(style_bottleneck, preprocessed_content_image):
-#   # Load the model.
-#   interpreter = tf.lite.Interpreter(model_path=style_transform_path)
+# Load the model.
+{:ok, interpreter} = TFLite.Interpreter.new(data_files.style_transform)
 
-#   # Set model input.
-#   input_details = interpreter.get_input_details()
-#   interpreter.allocate_tensors()
+# Get input and output tensors.
+{:ok, input_tensors} = TFLite.Interpreter.inputs(interpreter)
+{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
 
-#   # Set model inputs.
-#   interpreter.set_tensor(input_details[0]["index"], preprocessed_content_image)
-#   interpreter.set_tensor(input_details[1]["index"], style_bottleneck)
-#   interpreter.invoke()
+# Run the model.
+TFLite.Interpreter.input_tensor(interpreter, 0, Nx.to_binary(preprocessed_content.tensor))
+TFLite.Interpreter.input_tensor(interpreter, 1, style_bottleneck_data)
+TFLite.Interpreter.invoke(interpreter)
 
-#   # Transform content image.
-#   stylized_image = interpreter.tensor(
-#       interpreter.get_output_details()[0]["index"]
-#       )()
+# Transform content image.
+{:ok, output_tensors} = TFLite.Interpreter.outputs(interpreter)
+{:ok, output_data} = TFLite.Interpreter.output_tensor(interpreter, 0)
+out_tensor = TFLite.Interpreter.tensor(interpreter, Enum.at(output_tensors, 0))
+[1 | shape] = TFLite.TFLiteTensor.dims(out_tensor)
+type = TFLite.TFLiteTensor.type(out_tensor)
 
-#   return stylized_image
-
-# # Stylize the content image using the style bottleneck.
-# stylized_image = run_style_transform(style_bottleneck, preprocessed_content_image)
-
-# # Visualize the output.
-# imshow(stylized_image, 'Stylized Image')
+# Visualize the output.
+out_tensor
+|> TFLiteTensor.to_nx(backend: Nx.BinaryBackend)
+# Change the range from [0..1] to [0..255]
+|> Nx.multiply(255)
+|> Nx.reshape(List.to_tuple(shape))
+|> Nx.as_type({:u, 8})
+|> Cv.Mat.from_nx_2d()
+|> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR())
 ```
 
 ### Style blending

--- a/examples/artistic_style_transfer.livemd
+++ b/examples/artistic_style_transfer.livemd
@@ -1,0 +1,240 @@
+# Artistic Style Transfer with TensorFlow Lite
+
+```elixir
+Mix.install([
+  {:tflite_elixir, "~> 0.1.4"},
+  {:evision, "~> 0.1.8"},
+  {:kino, "~> 0.8.0"},
+  {:req, "~> 0.3.0"}
+])
+```
+
+## Introduction
+
+One of the most exciting developments in deep learning to come out recently is
+[artistic style transfer](https://arxiv.org/abs/1508.06576), or the ability to
+create a new image, known as a
+[pastiche](https://en.wikipedia.org/wiki/Pastiche), based on two input images:
+one representing the artistic style and one representing the content.
+
+Using this technique, we can generate beautiful new artworks in a range of
+styles.
+
+https://www.tensorflow.org/lite/examples/style_transfer/overview
+
+## Understand the model architecture
+
+![](https://storage.googleapis.com/download.tensorflow.org/models/tflite/arbitrary_style_transfer/architecture.png)
+
+This Artistic Style Transfer model consists of two submodels:
+
+1. **Style Prediciton Model**: A MobilenetV2-based neural network that takes an
+   input style image to a 100-dimension style bottleneck vector.
+2. **Style Transform Model**: A neural network that takes apply a style
+   bottleneck vector to a content image and creates a stylized image.
+
+## Download data files
+
+Download the content and style images, and the pre-trained TensorFlow Lite models.
+
+```elixir
+downloads_dir = System.tmp_dir!()
+# for nerves demo user
+# change to a directory with write-permission
+# downloads_dir = "/data/livebook"
+
+download = fn url ->
+  save_as = Path.join(downloads_dir, URI.encode_www_form(url))
+
+  unless File.exists?(save_as) do
+    %{status: 200} = Req.get!(url, output: save_as)
+  end
+
+  save_as
+end
+
+data_files =
+  [
+    {
+      :content,
+      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/belfry-2611573_1280.jpg"
+    },
+    {
+      :style,
+      "https://storage.googleapis.com/khanhlvg-public.appspot.com/arbitrary-style-transfer/style23.jpg"
+    },
+    {
+      :style_predict,
+      "https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/int8/prediction/1?lite-format=tflite"
+    },
+    {
+      :style_transform,
+      "https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/int8/transfer/1?lite-format=tflite"
+    }
+  ]
+  |> Enum.map(fn {key, url} ->
+    Task.async(fn -> {key, download.(url)} end)
+  end)
+  |> Task.await_many(:timer.seconds(30))
+  |> Map.new()
+```
+
+## Alias modules
+
+```elixir
+alias Evision, as: Cv
+alias TFLiteElixir, as: TFLite
+```
+
+## Pre-process the inputs
+
+* The content image and the style image must be RGB images with pixel values
+  being float32 numbers between [0..1].
+* The style image size must be (1, 256, 256, 3). We central crop the image and
+  resize it.
+* The content image must be (1, 384, 384, 3). We central crop the image and
+  resize it.
+
+```elixir
+# Function to load an image from a file, and add a batch dimension.
+load_img = fn path_to_img ->
+  %Nx.Tensor{} =
+    path_to_img
+    |> Cv.imread()
+    |> Cv.cvtColor(Cv.Constant.cv_COLOR_BGR2RGB(), dstCn: 3)
+    |> Cv.Mat.to_nx()
+    |> Nx.new_axis(0)
+    |> Nx.as_type({:f, 32})
+end
+
+# Function to pre-process by resizing an central cropping it.
+preprocess_image = fn image, target_dim ->
+  nil
+  # TODO: convert python to elixir
+  #
+  # # Resize the image so that the shorter dimension becomes 256px.
+  # shape = tf.cast(tf.shape(image)[1:-1], tf.float32)
+  # short_dim = min(shape)
+  # scale = target_dim / short_dim
+  # new_shape = tf.cast(shape * scale, tf.int32)
+  # image = tf.image.resize(image, new_shape)
+
+  # # Central crop the image.
+  # image = tf.image.resize_with_crop_or_pad(image, target_dim, target_dim)
+end
+
+# Load the input images.
+content_image = %Nx.Tensor{} = load_img.(data_files.content)
+style_image = %Nx.Tensor{} = load_img.(data_files.style)
+
+# # Preprocess the input images.
+# preprocessed_content_image = preprocess_image.(content_image, 384)
+# preprocessed_style_image = preprocess_image.(style_image, 256)
+
+# IO.puts("Style Image Shape:", preprocessed_style_image.shape)
+# IO.puts("Content Image Shape:", preprocessed_content_image.shape)
+```
+
+## Visualize the inputs
+
+```elixir
+# def imshow(image, title=None):
+#   if len(image.shape) > 3:
+#     image = tf.squeeze(image, axis=0)
+
+#   plt.imshow(image)
+#   if title:
+#     plt.title(title)
+
+# plt.subplot(1, 2, 1)
+# imshow(preprocessed_content_image, 'Content Image')
+
+# plt.subplot(1, 2, 2)
+# imshow(preprocessed_style_image, 'Style Image')
+```
+
+## Run style transfer with TensorFlow Lite
+
+### Style prediction
+
+```elixir
+# # Function to run style prediction on preprocessed style image.
+# def run_style_predict(preprocessed_style_image):
+#   # Load the model.
+#   interpreter = tf.lite.Interpreter(model_path=style_predict_path)
+
+#   # Set model input.
+#   interpreter.allocate_tensors()
+#   input_details = interpreter.get_input_details()
+#   interpreter.set_tensor(input_details[0]["index"], preprocessed_style_image)
+
+#   # Calculate style bottleneck.
+#   interpreter.invoke()
+#   style_bottleneck = interpreter.tensor(
+#       interpreter.get_output_details()[0]["index"]
+#       )()
+
+#   return style_bottleneck
+
+# # Calculate style bottleneck for the preprocessed style image.
+# style_bottleneck = run_style_predict(preprocessed_style_image)
+# print('Style Bottleneck Shape:', style_bottleneck.shape)
+```
+
+### Style transform
+
+```elixir
+# # Run style transform on preprocessed style image
+# def run_style_transform(style_bottleneck, preprocessed_content_image):
+#   # Load the model.
+#   interpreter = tf.lite.Interpreter(model_path=style_transform_path)
+
+#   # Set model input.
+#   input_details = interpreter.get_input_details()
+#   interpreter.allocate_tensors()
+
+#   # Set model inputs.
+#   interpreter.set_tensor(input_details[0]["index"], preprocessed_content_image)
+#   interpreter.set_tensor(input_details[1]["index"], style_bottleneck)
+#   interpreter.invoke()
+
+#   # Transform content image.
+#   stylized_image = interpreter.tensor(
+#       interpreter.get_output_details()[0]["index"]
+#       )()
+
+#   return stylized_image
+
+# # Stylize the content image using the style bottleneck.
+# stylized_image = run_style_transform(style_bottleneck, preprocessed_content_image)
+
+# # Visualize the output.
+# imshow(stylized_image, 'Stylized Image')
+```
+
+### Style blending
+
+```elixir
+# # Calculate style bottleneck of the content image.
+# style_bottleneck_content = run_style_predict(
+#   preprocess_image(content_image, 256)
+# )
+```
+
+```elixir
+# # Define content blending ratio between [0..1].
+# # 0.0: 0% style extracts from content image.
+# # 1.0: 100% style extracted from content image.
+# content_blending_ratio = 0.5
+
+# # Blend the style bottleneck of style image and content image
+# style_bottleneck_blended = content_blending_ratio * style_bottleneck_content \
+#                            + (1 - content_blending_ratio) * style_bottleneck
+
+# # Stylize the content image using the style bottleneck.
+# stylized_image_blended = run_style_transform(style_bottleneck_blended,
+#                                              preprocessed_content_image)
+
+# # Visualize the output.
+# imshow(stylized_image_blended, 'Blended Stylized Image')
+```


### PR DESCRIPTION
[![Run in Livebook](https://livebook.dev/badge/v1/gray.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fmnishiguchi%2Ftflite_elixir%2Fblob%2Fmnishiguchi%2Fartistic-style-transfer%2Fexamples%2Fartistic_style_transfer.livemd)

original example: https://www.tensorflow.org/lite/examples/style_transfer/overview