### PR TITLE
doc: fix the "Super Resolution" notebook

### DIFF
--- a/examples/super_resolution.livemd
+++ b/examples/super_resolution.livemd
@@ -2,8 +2,8 @@
 
 ```elixir
 Mix.install([
-  {:tflite_elixir, "~> 0.1.4"},
-  {:evision, "~> 0.1.8"},
+  {:tflite_elixir, "0.1.4"},
+  {:evision, "0.1.29"},
   {:kino, "~> 0.8.0"},
   {:req, "~> 0.3.0"}
 ])

--- a/examples/super_resolution.livemd
+++ b/examples/super_resolution.livemd
@@ -15,12 +15,10 @@ The task of recovering a high resolution (HR) image from its low resolution
 counterpart is commonly referred to as Single Image Super Resolution (SISR).
 
 The model used here is [Enhanced Super-Resolution Generative Adversarial
-Networks (ESRGAN)][ESRGAN]. And we are going to use TensorFlow Lite to run
+Networks (ESRGAN)](https://arxiv.org/abs/1809.00219). And we are going to use TensorFlow Lite to run
 inference on the pretrained model.
 
 https://www.tensorflow.org/lite/examples/super_resolution/overview
-
-[ESRGAN]: https://arxiv.org/abs/1809.00219
 
 ## Download data files
 

--- a/examples/super_resolution.livemd
+++ b/examples/super_resolution.livemd
@@ -99,17 +99,11 @@ sr =
 ```elixir
 data_files.test_img
 |> Cv.imread()
-|> then(&Cv.imencode(".jpeg", &1))
-|> IO.iodata_to_binary()
-|> Kino.Image.new(:jpeg)
 ```
 
 ```elixir
 sr
-|> Cv.Mat.from_nx()
+|> Cv.Mat.from_nx_2d()
 |> Cv.cvtColor(Cv.Constant.cv_COLOR_RGB2BGR())
-|> then(&Cv.imencode(".jpeg", &1))
-|> IO.iodata_to_binary()
-|> Kino.Image.new(:jpeg)
 ```
 


### PR DESCRIPTION
[![Run in Livebook](https://livebook.dev/badge/v1/gray.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fmnishiguchi%2Ftflite_elixir%2Fblob%2Fmnishiguchi%2Fimprove-super-resolution-notebook%2Fexamples%2Fsuper_resolution.livemd)

### Fixed

- Fix a broken ESRGAN link in the "Introduction" section
- Fix the code in the "Visualize the result" section for correct color

### Changed

- Lock `tflite_elixir` to `0.1.4`
- Lock `evision` to `0.1.29` 

The version locking is for surviving the potential breaking changes.