### PR TITLE
fix: build platform-specific binaries into the app's _build dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Platform-specific binaries now go to the consuming app's `_build/<target>_<env>/lib/tflite_beam/priv`
+  instead of `deps/tflite_beam/priv`, so switching `MIX_TARGET` no longer picks up
+  another target's `tflite_beam.so`. `rm -rf deps/tflite_beam` is no longer needed
+  when cross-compiling ([#73](https://github.com/cocoa-xu/tflite_beam/issues/73)).
+
 ## v0.3.10 (2026-06-30)
 [Browse the Repository](https://github.com/cocoa-xu/tflite_beam/tree/v0.3.10) | [Released Assets](https://github.com/cocoa-xu/tflite_beam/releases/tag/v0.3.10)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
+SOURCE_PRIV_DIR = $(shell pwd)/priv
+
+# Mix does not export MIX_APP_PATH when it builds a rebar3 dependency, but it does
+# point REBAR_BARE_COMPILER_OUTPUT_DIR at _build/<target>_<env>/lib/tflite_beam.
+# Using it keeps the artifacts of each MIX_TARGET apart, instead of having every
+# target overwrite the same deps/tflite_beam/priv.
+ifndef MIX_APP_PATH
+ifdef REBAR_BARE_COMPILER_OUTPUT_DIR
+	MIX_APP_PATH=$(REBAR_BARE_COMPILER_OUTPUT_DIR)
+endif
+endif
+
 ifndef MIX_APP_PATH
 	MIX_APP_PATH=$(shell pwd)/_build/default/lib/tflite_beam
-	PRIV_DIR=$(shell pwd)/priv
+	PRIV_DIR=$(SOURCE_PRIV_DIR)
 	LIBUSB_INSTALL_DIR=$(shell pwd)/libusb
 else
 	PRIV_DIR = $(MIX_APP_PATH)/priv
@@ -93,11 +105,22 @@ MAKE_BUILD_FLAGS ?= auto
 
 build: $(NATIVE_BINDINGS_SO) fix_libusb
 
-$(PRIV_DIR):
-	@ if [ ! -d "$(PRIV_DIR)" ]; then \
-		rm -rf "$(PRIV_DIR)" ; \
-		mkdir -p "$(PRIV_DIR)" ; \
-	fi
+# Before running us, Mix links a dependency's source priv into the _build target it
+# is compiling for -- as a symlink when that directory is absent, but by copying the
+# contents in when it already exists. Either way the artifacts of one target leak
+# into another, so a source priv means this target's priv cannot be trusted and is
+# rebuilt from scratch. Has to be phony: a symlink makes the directory look like it
+# already exists, so a directory target would never run.
+.PHONY: prepare_priv_dir
+prepare_priv_dir:
+	@ if [ "$(PRIV_DIR)" != "$(SOURCE_PRIV_DIR)" ]; then \
+		if [ -e "$(SOURCE_PRIV_DIR)" ]; then \
+			rm -rf "$(SOURCE_PRIV_DIR)" "$(PRIV_DIR)" ; \
+		elif [ -L "$(PRIV_DIR)" ]; then \
+			rm -f "$(PRIV_DIR)" ; \
+		fi ; \
+	fi ; \
+	mkdir -p "$(PRIV_DIR)"
 
 create_cache_dir:
 	@ mkdir -p "$(TFLITE_BEAM_CACHE_DIR)"
@@ -129,7 +152,7 @@ unarchive_source_code: $(TFLITE_SOURCE_ZIP)
 		fi \
 	fi
 
-install_libedgetpu_runtime:
+install_libedgetpu_runtime: prepare_priv_dir
 	@ if [ "$(TFLITE_BEAM_CORAL_SUPPORT)" = "true" ]; then \
 		bash scripts/copy_libedgetpu_runtime.sh "$(LIBEDGETPU_RUNTIME_PRIV)" "$(TFLITE_BEAM_CORAL_LIBEDGETPU_UNZIPPED_DIR)" "$(TFLITE_BEAM_CORAL_LIBEDGETPU_TRIPLET)" "$(TFLITE_BEAM_CORAL_USB_THROTTLE)" "$(TFLITE_BEAM_CORAL_LIBEDGETPU_URL)" "$(TFLITE_BEAM_CORAL_LIBEDGETPU_RUNTIME)" "$(TFLITE_BEAM_CACHE_DIR)" && \
 		if [ "$(TFLITE_BEAM_PREFER_PRECOMPILED)" != "true" ]; then \
@@ -141,7 +164,7 @@ install_libedgetpu_runtime:
 		fi \
 	fi
 
-libusb: create_cache_dir
+libusb: create_cache_dir prepare_priv_dir
 	@ if [ "$(TFLITE_BEAM_PREFER_PRECOMPILED)" != "true" ]; then \
 		if [ "$(TFLITE_BEAM_CORAL_SUPPORT)" = "true" ]; then \
 			echo "LIBUSB_SHARED_LIBRARY: $(LIBUSB_SHARED_LIBRARY)" ; \
@@ -152,7 +175,7 @@ libusb: create_cache_dir
 		fi \
 	fi
 
-$(UNICODE_DATA): $(PRIV_DIR)
+$(UNICODE_DATA): prepare_priv_dir
 	@ if [ ! -e "$(UNICODE_DATA)" ]; then \
 		cp -f "$(UNICODEDATA)/unicode_data.txt" "$(UNICODE_DATA)" ; \
 	fi
@@ -161,8 +184,9 @@ $(NATIVE_BINDINGS_SO): $(UNICODE_DATA) unarchive_source_code install_libedgetpu_
 	@ if [ "$(TFLITE_BEAM_PREFER_PRECOMPILED)" = "true" ]; then \
 		{ \
 			cd "$(shell pwd)" && \
-			erlc "$(PRECOMPILED_ERL_HELPER)" && \
-			erl -noshell -s tflite_beam_precompiled install_precompiled_binary_if_available -s init stop ; } || \
+			mkdir -p "$(MIX_APP_PATH)" && \
+			erlc -o "$(MIX_APP_PATH)" "$(PRECOMPILED_ERL_HELPER)" && \
+			TFLITE_BEAM_PRIV_DIR="$(PRIV_DIR)" erl -noshell -pa "$(MIX_APP_PATH)" -s tflite_beam_precompiled install_precompiled_binary_if_available -s init stop ; } || \
 		{ \
 			$(TFLITE_BEAM_MAKE) TFLITE_BEAM_PREFER_PRECOMPILED=false ; } ; \
 	fi && \

--- a/tflite_beam_precompiled.erl
+++ b/tflite_beam_precompiled.erl
@@ -3,11 +3,24 @@
 
 -define(PRECOMPILED_TARBALL_NAME, "tflite_beam-nif-~s-~s-v~s").
 -define(PRECOMPILED_DOWNLOAD_URL, "https://github.com/cocoa-xu/tflite_beam/releases/download/v~s/~s").
--define(TFLITE_BEAM_SO_FILE, "priv/tflite_beam.so").
--define(TFLITE_BEAM_DLL_FILE, "priv/tflite_beam.dll").
 -define(LIBEDGETPU_RUNTIME_VERSION, "0.1.14").
 
 -include_lib("kernel/include/file.hrl").
+
+%% Set by the Makefile so the tarball lands in the same per-target directory the
+%% rest of the build writes to, instead of always in the source tree.
+priv_dir() ->
+    case os:getenv("TFLITE_BEAM_PRIV_DIR") of
+        false -> "priv";
+        "" -> "priv";
+        Dir -> Dir
+    end.
+
+tflite_beam_so_file() ->
+    filename:join(priv_dir(), "tflite_beam.so").
+
+tflite_beam_dll_file() ->
+    filename:join(priv_dir(), "tflite_beam.dll").
 
 app_version() ->
     {ok, Cwd} = file:get_cwd(),
@@ -332,9 +345,9 @@ do_download(URL) ->
 is_already_installed() ->
     case string:find(get_target(), "windows-msvc") of
         nomatch ->
-            filelib:is_regular(?TFLITE_BEAM_SO_FILE);
+            filelib:is_regular(tflite_beam_so_file());
         _ ->
-            filelib:is_regular(?TFLITE_BEAM_DLL_FILE)
+            filelib:is_regular(tflite_beam_dll_file())
     end.
 
 install_precompiled_binary_if_available() ->
@@ -346,17 +359,22 @@ install_precompiled_binary_if_available() ->
                         {error, _} ->
                             exit(failed);
                         {ok, TarballFileFullPath} ->
-                            file:del_dir_r("tmp_priv"),
-                            Status = 
-                                case erl_tar:extract(TarballFileFullPath, [compressed, {cwd, "tmp_priv"}]) of
+                            PrivDir = priv_dir(),
+                            %% Unarchive next to the destination so the rename below
+                            %% stays within one filesystem.
+                            TmpDir = filename:join(filename:dirname(PrivDir), "tmp_priv"),
+                            filelib:ensure_dir(filename:join(PrivDir, ".keep")),
+                            file:del_dir_r(TmpDir),
+                            Status =
+                                case erl_tar:extract(TarballFileFullPath, [compressed, {cwd, TmpDir}]) of
                                     ok ->
-                                        file:del_dir_r("priv"),
-                                        TmpPriv = filename:join(["tmp_priv", Name, "priv"]),
-                                        
-                                        PrivRenameOk = file:rename(TmpPriv, "priv"),
+                                        file:del_dir_r(PrivDir),
+                                        TmpPriv = filename:join([TmpDir, Name, "priv"]),
+
+                                        PrivRenameOk = file:rename(TmpPriv, PrivDir),
                                         case PrivRenameOk of
                                             {error, PrivError} ->
-                                                io:fwrite("[ERROR] Failed to move priv directory: ~p~n", [PrivError]),
+                                                io:fwrite("[ERROR] Failed to move priv directory to ~ts: ~p~n", [PrivDir, PrivError]),
                                                 failed;
                                             _ ->
                                                 ok
@@ -365,7 +383,7 @@ install_precompiled_binary_if_available() ->
                                         io:fwrite("[ERROR] Failed to unarchive tarball file: ~s, error: ~p~n", [TarballFileFullPath, Error]),
                                         failed
                                 end,
-                            file:del_dir_r("tmp_priv"),
+                            file:del_dir_r(TmpDir),
                             case Status of 
                                 failed ->
                                     exit(failed);


### PR DESCRIPTION
Closes #73.

## Problem

Building for one `MIX_TARGET` and then another reuses the first target's
`tflite_beam.so`, so switching targets requires `rm -rf deps/tflite_beam`.

## Root cause

Three layers, all confirmed against the Elixir/rebar3 sources:

1. **Mix never sets `MIX_APP_PATH` for a rebar3 dependency.** It is an
   `elixir_make` variable — `grep -rn MIX_APP_PATH lib/mix` returns zero hits.
   So the `ifndef MIX_APP_PATH` branch in the Makefile always won and `PRIV_DIR`
   resolved to `deps/tflite_beam/priv`.
2. **Mix then links that one directory into every target it builds.**
   `Mix.Tasks.Deps.Compile.do_rebar3` runs `Mix.Utils.symlink_or_copy/2` over
   `include`/`priv`/`src` before and after invoking rebar3, so
   `_build/<target>_<env>/lib/tflite_beam/priv` became a symlink back into the
   single source directory shared by every target.
3. **`tflite_beam_precompiled.erl` hardcoded `"priv"` relative to cwd**, so the
   precompiled path wrote into the source tree even if `MIX_APP_PATH` were set.

The build's own up-to-date guards (`[ ! -e $(NATIVE_BINDINGS_SO) ]` and
`is_already_installed/0`) then saw a stale wrong-architecture `.so` and skipped
the rebuild.

## Fix

Mix does export `REBAR_BARE_COMPILER_OUTPUT_DIR`, pointing at
`_build/<target>_<env>/lib/tflite_beam` — the rebar3-side counterpart of
`MIX_APP_PATH`, and a contract both Mix and rebar3 maintain deliberately. Using
it makes `PRIV_DIR`, `LIBUSB_INSTALL_DIR` and both cmake build dirs per-target
automatically. This is the same idiom `silviucpp/erlkaf` uses in `c_src/nif.mk`.

`prepare_priv_dir` replaces the old `$(PRIV_DIR)` directory target. It must be
phony — a symlink makes the directory look like it already exists, so a
directory target would never run. It also handles the two ways Mix links the
source priv in: a symlink when the target directory is absent, and a merging
`File.cp_r!` when it already exists. A source `priv/` therefore means this
target's priv cannot be trusted and gets rebuilt from scratch, which is also
what migrates existing checkouts without `rm -rf deps/tflite_beam`.

Standalone `rebar3 compile` is deliberately unchanged and still writes to
`./priv`, which is what both precompile workflows package via `cp -a ./priv`.

## Verification

Real Mix app depending on this repo, on macOS arm64 / OTP 28 / Elixir 1.20.

Built from source (`TFLITE_BEAM_PREFER_PRECOMPILED=false`, Coral enabled):

- `.so`, `libedgetpu`, `libusb` and `cmake_tflite_beam` all land under
  `_build/dev/lib/tflite_beam/`; the source tree keeps no `priv/`, `libusb/`,
  `cmake_tflite_beam/` or stray `.beam`
- `priv` is a real directory, not a symlink
- rpath fix still applied (`@loader_path/libedgetpu`), NIF loads and executes,
  and `tflite_beam_coral:edge_tpu_devices/0` returns `[]` rather than failing to
  resolve the dylib

Cross-target isolation, precompiled path:

| | |
|---|---|
| `_build/dev/.../priv/tflite_beam.so` | Mach-O arm64 |
| `_build/rpi4_dev/.../priv/tflite_beam.so` | ELF 32-bit ARM EABI5 |

Also checked: migration from an existing in-source `priv/`, repeated and
`--force` rebuilds, incremental builds not forced to rebuild from scratch,
standalone `rebar3 compile` still producing `./priv/tflite_beam.so` so
`cp -a ./priv` keeps working, and the Makefile parsing on stock macOS GNU Make
3.81.

Not covered: a real Nerves toolchain (cross-targets were exercised via
`TARGET_ARCH`/`TARGET_OS`/`TARGET_ABI` and the precompiled tarballs), a hex
dependency rather than a path dependency, and the Windows `nmake` branch.
