### PR TITLE
fix: build glog without a system-wide gflags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   instead of `deps/tflite_beam/priv`, so switching `MIX_TARGET` no longer picks up
   another target's `tflite_beam.so`. `rm -rf deps/tflite_beam` is no longer needed
   when cross-compiling ([#73](https://github.com/cocoa-xu/tflite_beam/issues/73)).
+- Building from source no longer fails on hosts that have gflags installed
+  system-wide (e.g. `brew install gflags`). glog resolved gflags through
+  `find_package`, which picked up the system copy and collided with the targets
+  the bundled gflags had already defined.
 
 ## v0.3.10 (2026-06-30)
 [Browse the Repository](https://github.com/cocoa-xu/tflite_beam/tree/v0.3.10) | [Released Assets](https://github.com/cocoa-xu/tflite_beam/releases/tag/v0.3.10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ if(${TFLITE_BEAM_CORAL_SUPPORT})
         "Directory that contains the glog project"
     )
 
+    # glog looks up gflags with find_package, which can only ever resolve to a
+    # system-wide copy -- never the one added above -- and the two sets of targets
+    # then collide. Build hosts have no system gflags, so this is also the
+    # configuration every released binary is already built with.
+    set(WITH_GFLAGS OFF CACHE BOOL "Use gflags" FORCE)
+
     add_subdirectory(
         "${GLOG_ROOT_DIR}"
         EXCLUDE_FROM_ALL


### PR DESCRIPTION
## Problem

Building from source fails during configure on any host that has gflags
installed system-wide (`brew install gflags`, or a distro `libgflags-dev`):

```
CMake Error at /opt/homebrew/lib/cmake/gflags/gflags-nonamespace-targets.cmake:42 (message):
  Some (but not all) targets in this export set were already defined.

  Targets Defined: gflags_nothreads_static
  Targets not yet defined: gflags_shared, gflags_nothreads_shared, gflags_static

Call Stack (most recent call first):
  /opt/homebrew/lib/cmake/gflags/gflags-config.cmake:17 (include)
  3rd_party/glog/CMakeLists.txt:78 (find_package)
```

## Cause

`CMakeLists.txt` pulls in the bundled gflags and glog with `add_subdirectory`,
but `3rd_party/glog/CMakeLists.txt` resolves gflags with `find_package(gflags 2.2.2)`.
`find_package` can only ever locate a copy installed system-wide — it cannot see
the bundled gflags that was just added to the same build tree — so it imports the
system export set on top of targets the bundled gflags already defined, and
configuring aborts.

Even where the target names happened not to collide, this would link glog against
a *different* gflags than the one `tflite_beam` itself links.

## Fix

Build hosts have no system gflags, so `find_package` already comes up empty there
and every released binary is built with glog not using gflags. `WITH_GFLAGS=OFF`
makes that the stated configuration instead of something that depends on what
happens to be installed on the machine.

## Verification

macOS arm64, OTP 28 / Elixir 1.20, with `gflags` present at
`/opt/homebrew/lib/cmake/gflags/` and **no** workaround such as
`CMAKE_IGNORE_PREFIX_PATH`:

- before this change: configure fails with the error above
- after: `Configuring done` / `Generating done`, full build to
  `[100%] Built target tflite_beam`
- NIF loads and executes, and `tflite_beam_coral:edge_tpu_devices/0` returns `[]`
  rather than failing to resolve libedgetpu — so the glog/libedgetpu path still works
- the resulting `tflite_beam.so` is the same size (9128544 bytes) as one built on a
  host where the system gflags is hidden, i.e. the build output is unchanged and
  only the dependence on host state is removed
- `otool -L` shows no linkage to any system gflags or glog

Rebased onto `main` after #74 merged; the CHANGELOG entries for both now sit
under the same `## Unreleased` / `### Fixed` heading.
